### PR TITLE
Remove the Commenting.DocComment.MissingShort rule that caused issues with CBF

### DIFF
--- a/HelpScout/ruleset.xml
+++ b/HelpScout/ruleset.xml
@@ -46,11 +46,6 @@
  <!-- Add additional Help Scout sniffs -->
  <rule ref="HelpScout.Functions.DisallowXDebug"/>
 
- <!-- Allow us to use the compact phpdoc format -->
- <rule ref="Generic.Commenting.DocComment">
-  <exclude name="Generic.Commenting.DocComment.MissingShort"/>
- </rule>
-
  <!-- Allow an exception to concat rules for long line lengths -->
  <rule ref="Generic.Strings.UnnecessaryStringConcat">
   <properties>


### PR DESCRIPTION
Using a simple test file:

```
<?php

class Test
{
    /** @var int */
    public $test;
}
```

The PHPCBF tool would format the docblock onto multiple lines but with the wrong tabbing.

```
<?php

class Test
{
    /**
 * @var int
*/
    public $test;
}
```

Without the rule it leaves the docblock as a short docblock.