### PR TITLE
Relax bracket and phpdoc linting

### DIFF
--- a/HelpScout/ruleset.xml
+++ b/HelpScout/ruleset.xml
@@ -7,9 +7,7 @@
  <rule ref="PSR2"/>
 
  <!-- Include some specific sniffs -->
- <rule ref="Generic.Arrays.ArrayIndent"/>
  <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
- <rule ref="Generic.Commenting.Todo"/>
  <rule ref="Generic.ControlStructures.InlineControlStructure"/>
  <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
  <rule ref="Generic.Formatting.SpaceAfterCast"/>
@@ -24,7 +22,6 @@
  <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
  <rule ref="Generic.WhiteSpace.ScopeIndent"/>
  <rule ref="PEAR.ControlStructures.MultiLineCondition"/>
- <rule ref="PEAR.Files.IncludingFile"/>
  <rule ref="PEAR.Formatting.MultiLineAssignment"/>
  <rule ref="PEAR.Functions.ValidDefaultValue"/>
  <rule ref="PSR2.Files.EndFileNewline"/>
@@ -100,13 +97,16 @@
   <properties>
    <property name="allowMultipleArguments" value="false"/>
   </properties>
+  <exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
+  <exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
  </rule>
 
  <!-- Relaxing several commenting sniffs from Squiz -->
  <rule ref="Squiz.Commenting.FunctionComment">
-  <!-- Make sure that each parameter is included in the doc block -->
   <exclude name="Squiz.Commenting.FunctionComment.EmptyThrows"/>
   <exclude name="Squiz.Commenting.FunctionComment.Missing"/>
+  <exclude name="Squiz.Commenting.FunctionComment.MissingReturn"/>
+  <exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
   <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
   <exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
   <exclude name="Squiz.Commenting.FunctionComment.ParamCommentNotCapital"/>


### PR DESCRIPTION
## Feature
With some PHP7 changes it makes sense to relax some standards a bit more. 

## Changes

1. Allow omission of phpdoc comments for type hinted parameters
1. Relax the conditional `require`/`include` rule, PEAR is simply wrong about that.
1. Allow nested arrays in function calls.

```php
$transaction = new TaxableTransactionModel([
    'pretaxTotal'        => $faker->randomFloat(2, 1, 2000),
    'taxableCompanyUuid' => $response->uuid,
    'date'               => date(TaxableTransactionModel::DATE_FORMAT),
    'description'        => $faker->sentence(3),
    'line1'              => '2309 6th Ave',
    'city'               => 'Tacoma',
    'region'             => 'WA',
    'postalCode'         => '98403',
    'country'            => 'US',
]);```