### PR TITLE
Move & Update Code Sniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
       "issues": "https://github.com/helpscout/php-standards/issues"
     },
     "minimum-stability": "dev",
-    "require": {},
-    "require-dev": {
-        "squizlabs/php_codesniffer": "^3.2"
+    "require": {
+      "squizlabs/php_codesniffer": "^3.3"
     },
+    "require-dev": {},
     "scripts": {
       "phpcs": "phpcs --standard=HelpScout --extensions=php examples"
     }


### PR DESCRIPTION
Including this in the dependencies instead of dev dependencies means the correct version will be installed on our projects which require this library. This allows the version to stay in sync. Scout-cli ran into an issue with having conflicting/outdated version of codesniffer. 

I also updated to the latest tagged version.