### PR TITLE
Update Help Scout Standards with PSR12 rules

### DIFF
--- a/HelpScout/Sniffs/Functions/DisallowXDebugSniff.php
+++ b/HelpScout/Sniffs/Functions/DisallowXDebugSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This sniff prohibits the use of xdebug functions in production code
+ * Prohibits the use of xdebug functions in production code
  *
  * @author     Platform Team <developer@helpscout.net>
  * @copyright  2015 Help Scout
@@ -32,4 +32,3 @@ class HelpScout_Sniffs_Functions_DisallowXDebugSniff extends ForbiddenFunctionsS
     ];
 }
 
-/* End of file DisallowXDebugSniff.php */

--- a/HelpScout/ruleset.xml
+++ b/HelpScout/ruleset.xml
@@ -10,6 +10,11 @@
         <severity>0</severity>
     </rule>
 
+    <!-- Warn about statements that have no executable code. -->
+    <rule ref="Generic.CodeAnalysis.EmptyStatement">
+        <type>warning</type>
+    </rule>
+
     <!-- Verifies that inline control statements are not present. -->
     <rule ref="Generic.ControlStructures.InlineControlStructure"/>
 

--- a/HelpScout/ruleset.xml
+++ b/HelpScout/ruleset.xml
@@ -1,117 +1,153 @@
 <?xml version="1.0"?>
 <ruleset name="HelpScout">
- <description>The Help Scout Coding Standard.</description>
+    <description>The Help Scout PHP Coding Standard.</description>
 
- <!-- Include PSR standards -->
- <rule ref="PSR1"/>
- <rule ref="PSR2"/>
+    <!-- Include PSR12 standards. -->
+    <rule ref="PSR12"/>
 
- <!-- Include some specific sniffs -->
- <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
- <rule ref="Generic.ControlStructures.InlineControlStructure"/>
- <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
- <rule ref="Generic.Formatting.SpaceAfterCast"/>
- <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
- <rule ref="Generic.NamingConventions.ConstructorName"/>
- <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
- <rule ref="Generic.PHP.DeprecatedFunctions"/>
- <rule ref="Generic.PHP.DisallowShortOpenTag"/>
- <rule ref="Generic.PHP.LowerCaseConstant"/>
- <rule ref="Generic.PHP.LowerCaseKeyword"/>
- <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
- <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
- <rule ref="Generic.WhiteSpace.ScopeIndent"/>
- <rule ref="PEAR.ControlStructures.MultiLineCondition"/>
- <rule ref="PEAR.Formatting.MultiLineAssignment"/>
- <rule ref="PEAR.Functions.ValidDefaultValue"/>
- <rule ref="PSR2.Files.EndFileNewline"/>
- <rule ref="Squiz.Commenting.VariableComment"/>
- <rule ref="Squiz.PHP.CommentedOutCode"/>
- <rule ref="Zend.Debug.CodeAnalyzer"/>
- <rule ref="Zend.Files.ClosingTag"/>
+    <!-- In files without a header comment, we don't want an extra newline -->
+    <rule ref="PSR12.Files.FileHeader.SpacingAfterBlock">
+        <severity>0</severity>
+    </rule>
 
- <!-- We prefer not to use underscores on private properties -->
- <rule ref="Squiz.NamingConventions.ValidVariableName">
-  <exclude name="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore"/>
- </rule>
+    <!-- Verifies that inline control statements are not present. -->
+    <rule ref="Generic.ControlStructures.InlineControlStructure"/>
 
- <!-- PHPStorm prefers throws annotations from deeper code as well, this causes
-      the number in the method and the number in the phpdoc to mismatch -->
- <rule ref="Squiz.Commenting.FunctionCommentThrowTag">
-  <exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>
- </rule>
+    <!-- Ensures each statement is on a line by itself. -->
+    <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
 
- <!-- Add additional Help Scout sniffs -->
- <rule ref="HelpScout.Functions.DisallowXDebug"/>
+    <!-- Ensures there is a single space after cast tokens. -->
+    <rule ref="Generic.Formatting.SpaceAfterCast"/>
 
- <!-- Allow an exception to concat rules for long line lengths -->
- <rule ref="Generic.Strings.UnnecessaryStringConcat">
-  <properties>
-   <property name="allowMultiline" value="true"/>
-  </properties>
- </rule>
+    <!-- Checks that calls to methods and functions are spaced correctly. -->
+    <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
 
- <!-- Controllers Violate PSR0 -->
- <rule ref="PSR1.Classes.ClassDeclaration">
-  <exclude-pattern>*/controllers/*</exclude-pattern>
- </rule>
- <rule ref="PSR1.Files.SideEffects">
-  <exclude-pattern>*/controllers/*</exclude-pattern>
- </rule>
+    <!-- Ensures that constant names are all uppercase. -->
+    <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
 
- <!-- Tests Violate PSR0 -->
- <rule ref="PSR1.Classes.ClassDeclaration">
-  <exclude-pattern>test/*</exclude-pattern>
- </rule>
+    <!-- Discourages the use of deprecated PHP functions. -->
+    <rule ref="Generic.PHP.DeprecatedFunctions"/>
 
- <!-- Lines can be 120 chars long, but never show errors -->
- <rule ref="Generic.Files.LineLength">
-  <properties>
-   <property name="lineLimit" value="80"/>
-   <property name="absoluteLineLimit" value="120"/>
-  </properties>
- </rule>
+    <!-- Makes sure that shorthand PHP open tags are not used. -->
+    <rule ref="Generic.PHP.DisallowShortOpenTag"/>
 
- <!-- Use Unix newlines -->
- <rule ref="Generic.Files.LineEndings">
-  <properties>
-   <property name="eolChar" value="\n"/>
-  </properties>
- </rule>
+    <!-- Checks that all uses of true, false and null are lowercase. -->
+    <rule ref="Generic.PHP.LowerCaseConstant"/>
 
- <!-- Have 20 chars padding maximum and always show as errors -->
- <rule ref="Generic.Formatting.MultipleStatementAlignment">
-  <properties>
-   <property name="maxPadding" value="20"/>
-   <property name="error" value="true"/>
-  </properties>
- </rule>
+    <!-- Checks that all PHP keywords are lowercase. -->
+    <rule ref="Generic.PHP.LowerCaseKeyword"/>
 
- <!-- We allow empty catch statements -->
- <rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedCATCH">
-  <severity>0</severity>
- </rule>
+    <!-- Throws errors if tabs are used for indentation. -->
+    <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
 
- <!-- Only one argument per line in multi-line function calls -->
- <rule ref="PEAR.Functions.FunctionCallSignature">
-  <properties>
-   <property name="allowMultipleArguments" value="false"/>
-  </properties>
-  <exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
-  <exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
- </rule>
+    <!-- Checks that control structures are defined and indented correctly. -->
+    <rule ref="Generic.WhiteSpace.ScopeIndent"/>
 
- <!-- Relaxing several commenting sniffs from Squiz -->
- <rule ref="Squiz.Commenting.FunctionComment">
-  <exclude name="Squiz.Commenting.FunctionComment.EmptyThrows"/>
-  <exclude name="Squiz.Commenting.FunctionComment.Missing"/>
-  <exclude name="Squiz.Commenting.FunctionComment.MissingReturn"/>
-  <exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
-  <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
-  <exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
-  <exclude name="Squiz.Commenting.FunctionComment.ParamCommentNotCapital"/>
-  <exclude name="Squiz.Commenting.FunctionComment.InvalidReturn"/>
-  <exclude name="Squiz.Commenting.FunctionComment.IncorrectParamVarName"/>
-  <exclude name="Squiz.Commenting.FunctionComment.InvalidTypeHint"/>
- </rule>
+    <!-- Ensures function params with default values are at the end of the declaration. -->
+    <rule ref="PEAR.Functions.ValidDefaultValue"/>
+
+    <!-- Ensures the file ends with a newline character. -->
+    <rule ref="PSR2.Files.EndFileNewline"/>
+
+    <!-- Parses and verifies the variable doc comment. -->
+    <rule ref="Squiz.Commenting.VariableComment">
+        <!-- Omit the boolean and integer long form type names in hints. -->
+        <exclude name="Squiz.Commenting.VariableComment.IncorrectVarType"/>
+    </rule>
+
+    <!-- Warn about commented out code. -->
+    <rule ref="Squiz.PHP.CommentedOutCode"/>
+
+    <!-- Checks that the file does not end with a closing tag. -->
+    <rule ref="Zend.Files.ClosingTag"/>
+
+    <!-- We prefer not to use underscores on private properties -->
+    <rule ref="Squiz.NamingConventions.ValidVariableName">
+        <exclude name="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore"/>
+    </rule>
+
+    <!-- PHPStorm prefers throws annotations from deeper code as well, -->
+    <!-- this causes the number in the method and the number in the phpdoc -->
+    <!-- to mismatch -->
+    <rule ref="Squiz.Commenting.FunctionCommentThrowTag">
+        <exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>
+    </rule>
+
+    <!-- Prohibit the use of xdebug functions in production code -->
+    <rule ref="HelpScout.Functions.DisallowXDebug"/>
+
+    <!-- HS-APP Controllers Violate PSR0 -->
+    <rule ref="PSR1.Classes.ClassDeclaration">
+        <exclude-pattern>*/controllers/*</exclude-pattern>
+    </rule>
+    <rule ref="PSR1.Files.SideEffects">
+        <exclude-pattern>*/controllers/*</exclude-pattern>
+    </rule>
+
+    <!-- HS-APP Tests Violate PSR0 -->
+    <rule ref="PSR1.Classes.ClassDeclaration">
+        <exclude-pattern>test/*</exclude-pattern>
+    </rule>
+
+    <!-- Lines can be 120 chars long, but never show errors -->
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="80"/>
+            <property name="absoluteLineLimit" value="120"/>
+        </properties>
+    </rule>
+
+    <!-- Use Unix newlines -->
+    <rule ref="Generic.Files.LineEndings">
+        <properties>
+            <property name="eolChar" value="\n"/>
+        </properties>
+    </rule>
+
+    <!-- Have 20 chars padding maximum and always show as errors -->
+    <rule ref="Generic.Formatting.MultipleStatementAlignment">
+        <properties>
+            <property name="maxPadding" value="8"/>
+            <property name="error" value="true"/>
+        </properties>
+    </rule>
+
+    <!-- We allow empty catch statements -->
+    <rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedCATCH">
+        <severity>0</severity>
+    </rule>
+
+    <!-- Only one argument per line in multi-line function calls -->
+    <rule ref="PEAR.Functions.FunctionCallSignature">
+        <properties>
+            <property name="allowMultipleArguments" value="false"/>
+        </properties>
+        <!-- Allow content after a open parenthesis. smarty($template, [\n -->
+        <exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments"/>
+        <exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
+        <!-- And the same for closing ]); -->
+        <exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
+    </rule>
+
+    <!-- Relaxing several commenting sniffs from Squiz -->
+    <rule ref="Squiz.Commenting.FunctionComment">
+        <!-- Comment missing for @throws tag in function comment -->
+        <exclude name="Squiz.Commenting.FunctionComment.EmptyThrows"/>
+        <!-- Allow no comment at all -->
+        <exclude name="Squiz.Commenting.FunctionComment.Missing"/>
+        <!-- Methods with type definitions don't need an @return -->
+        <exclude name="Squiz.Commenting.FunctionComment.MissingReturn"/>
+        <!-- Type hinted parameters don't need an @param -->
+        <exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
+        <!-- We don't mind a parameter without a comment. Well named is good enough -->
+        <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
+        <!-- No need for periods on the end of comments -->
+        <exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
+        <!-- No need for Capitalization rules, we're not publishing docs -->
+        <exclude name="Squiz.Commenting.FunctionComment.ParamCommentNotCapital"/>
+        <!-- We occasionally need to lie about Doctrine returns types -->
+        <exclude name="Squiz.Commenting.FunctionComment.IncorrectParamVarName"/>
+        <!-- We occasionally need to lie about Doctrine returns types -->
+        <exclude name="Squiz.Commenting.FunctionComment.InvalidTypeHint"/>
+    </rule>
 </ruleset>

--- a/HelpScout/ruleset.xml
+++ b/HelpScout/ruleset.xml
@@ -7,7 +7,7 @@
 
     <!-- In files without a header comment, we don't want an extra newline -->
     <rule ref="PSR12.Files.FileHeader.SpacingAfterBlock">
-        <severity>0</severity>
+        <type>warning</type>
     </rule>
 
     <!-- Warn about statements that have no executable code. -->

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,11 @@
     },
     "minimum-stability": "dev",
     "require": {
-      "squizlabs/php_codesniffer": "^3.3"
+      "squizlabs/php_codesniffer": "3.5.5"
     },
     "require-dev": {},
     "scripts": {
-      "phpcs": "phpcs --standard=HelpScout --extensions=php examples"
+      "sniff": "phpcs --standard=HelpScout --extensions=php -s examples/good",
+      "fail": "phpcs --standard=HelpScout --extensions=php examples/bad"
     }
 }

--- a/examples/bad/BadCode.php
+++ b/examples/bad/BadCode.php
@@ -1,0 +1,28 @@
+<?php
+namespace Vendor\Package;
+
+use FooInterface;
+use BarClass as Bar;
+use OtherVendor\OtherPackage\BazClass;
+
+/**
+ * This code should display failures and
+ */
+class BadCode extends Bar implements FooInterface
+{
+    public function sampleMethod($a, $b = null)
+    {
+        if ($a === $b) {
+            bar();
+        } elseif ($a > $b) {
+            $foo->bar($arg1);
+        } else {
+            BazClass::bar($arg2, $arg3);
+        }
+    }
+
+    final public static function bar()
+    {
+        // method body
+    }
+}

--- a/examples/bad/BadCode.php
+++ b/examples/bad/BadCode.php
@@ -6,7 +6,7 @@ use BarClass as Bar;
 use OtherVendor\OtherPackage\BazClass;
 
 /**
- * This code should display failures and
+ * This code should display failures when sniffed
  */
 class BadCode extends Bar implements FooInterface
 {

--- a/examples/bad/Closures.php
+++ b/examples/bad/Closures.php
@@ -1,0 +1,7 @@
+<?php
+
+// Closures should not have their bracket on a new line
+$closureWithArgsVarsAndReturn = function ($arg1, $arg2) use ($var1, $var2): bool
+{
+    return true;
+};

--- a/examples/good/AnonymousClasses.php
+++ b/examples/good/AnonymousClasses.php
@@ -1,0 +1,15 @@
+<?php
+
+// Brace on the same line
+$instance = new class extends \Batch implements \HandleableInterface {
+    // Class content
+};
+
+// Brace on the next line
+$instance = new class extends \Batch implements
+    \ArrayAccess,
+    \Countable,
+    \Serializable
+{
+    // Class content
+};

--- a/examples/good/Closures.php
+++ b/examples/good/Closures.php
@@ -1,0 +1,13 @@
+<?php
+
+$closureWithArgs = function ($arg1, $arg2) {
+    // body
+};
+
+$closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2) {
+    // body
+};
+
+$closureWithArgsVarsAndReturn = function ($arg1, $arg2) use ($var1, $var2): bool {
+    return true;
+};

--- a/examples/good/CompactCode.php
+++ b/examples/good/CompactCode.php
@@ -5,7 +5,7 @@ class CompactCode
 {
     public function __construct()
     {
-        smarty('path/to/template', [
+        \smarty('path/to/template', [
             'name' => 'John Smith',
             'age'  => 32,
         ]);

--- a/examples/good/CompactCode.php
+++ b/examples/good/CompactCode.php
@@ -1,0 +1,13 @@
+<?php
+namespace Vendor\Package;
+
+class CompactCode
+{
+    public function __construct()
+    {
+        smarty('path/to/template', [
+            'name' => 'John Smith',
+            'age'  => 32,
+        ]);
+    }
+}

--- a/examples/good/Expressions.php
+++ b/examples/good/Expressions.php
@@ -1,0 +1,8 @@
+<?php
+
+while (
+    $expr1
+    && $expr2
+) {
+    // structure body
+}

--- a/examples/good/Foo.php
+++ b/examples/good/Foo.php
@@ -1,24 +1,27 @@
 <?php
-/**
- * This is example code to confirm that the linter can run.
- */
 namespace Vendor\Package;
 
 use FooInterface;
 use BarClass as Bar;
 use OtherVendor\OtherPackage\BazClass;
 
+/**
+ * This is example code to confirm that the linter can run.
+ */
 class Foo extends Bar implements FooInterface
 {
-    public function sampleMethod($a, $b = null)
+    public function canHaveNoCommentIfTypeHinted(int $a, int $b = null): int
     {
         if ($a === $b) {
-            bar();
+            Bar();
         } elseif ($a > $b) {
-            $foo->bar($arg1);
+            $foo = new Foo();
+            $foo->bar($a);
         } else {
-            BazClass::bar($arg2, $arg3);
+            BazClass::bar($a, $b);
         }
+
+        return 6;
     }
 
     final public static function bar()

--- a/examples/good/Foo.php
+++ b/examples/good/Foo.php
@@ -24,6 +24,16 @@ class Foo extends Bar implements FooInterface
         return 6;
     }
 
+    public function emptyStatementIsWarningNotError()
+    {
+        $i = 0;
+        if ($i < 5) {
+            $i++;
+        } else {
+            // This should warn and not fail.
+        }
+    }
+
     final public static function bar()
     {
         // method body

--- a/examples/good/Properties.php
+++ b/examples/good/Properties.php
@@ -1,0 +1,24 @@
+<?php
+namespace Vendor\Package;
+
+class Properties
+{
+    /**
+     * Retire the cache after a period of time
+     */
+    const MAX_AGE_DAYS = 5;
+
+    /**
+     * We prefer bool and not boolean
+     *
+     * @var bool
+     */
+    public $canProcessUser;
+
+    /**
+     * We prefer int and not integer
+     *
+     * @var int
+     */
+    private $activeUserCount;
+}


### PR DESCRIPTION
# Feature

Upgrade Help Scout standards to be based on [the PSR12 extended coding style](https://www.php-fig.org/psr/psr-12/).

This PR makes also relaxes a few Help Scout specific rules, and I'll call those out below. I've also added comments in the ruleset file to explain each of the rules. 

# Composer Changes

1. Update to the latest [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer) release at [3.5.5](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.5.5).
2. Update the `composer sniff` command to use the `-s` option to print which sniff is in violation. This is helpful when writing exclusions.
3. Add a new `composer fail` to run the sniffer on the `examples/bad` folder.

# PSR12 Changes
Many of the new PSR12 rules were already a part of our Help Scout standard, and will not be new changes. The main changes of PSR12 are below, and I've indicated new rules with bold

* Files must use Unix line ending only
* Automated style checkers can emit error when passing 120 characters
* **Blank lines can't have trailing spaces**
* Each ident level must have 4 spaces for indentation
* Types must be in lowercase as reserved keywords
* **Use of short form of keywords is a must (int instead of integer, bool instead of boolean, etc)**

This PR relaxes one specific rule in PSR12. The `PSR12.Files.FileHeader.SpacingAfterBlock` rule is converted to a warning. This allows us to omit a header block from a file and use only a class comment. With this rule in place, the linter prefers an empty line after the file opening tag if a header comment is omitted, and that seems wasteful.

# Help Scout Changes
This PR relaxes several rules.

1. Convert `Generic.CodeAnalysis.EmptyStatement` to be a warning. This allows control structures with only comments in them to exist. We occasionally do this with catches and else's. This is now converted to a warning.
1. Remove `Generic.NamingConventions.ConstructorName`. This enforced PHP4 `__constructor` naming.
1. Remove `Generic.Strings.UnnecessaryStringConcat`. This seemed overly strict, it prevented some specific types of concat  `"foo" + "bar"`, but I think I could come up with a reason to do this.
1. Update the `VariableComment` rule with an exclusion for `Squiz.Commenting.VariableComment.IncorrectVarType`. Squiz has not yet updated their standard to prefer `int`, `bool` as phpdoc types. We'll skip this one as we seem to prefer to have our phpdoc match the type hints.
1. `Zend.Debug.CodeAnalyze`. I can't imagine anyone has this configured anymore.
1. Relax alignment rules. The `Generic.Formatting.MultipleStatementAlignment` now has a `maxPadding` of 8. This means that if you need to add more than 8 spaces to make inter-line alignment happen, you no longer need to make them align.

In particular, these changes allow some more flexible alignment for calls such as:

```php
<?php

\smarty('path/to/template', [
    'name' => 'John Smith',
    'age'  => 32,
]);
``` 
 