### PR TITLE
Add comments to Help Scout standards rulesets

### DIFF
--- a/HelpScout/Sniffs/Functions/DisallowXDebugSniff.php
+++ b/HelpScout/Sniffs/Functions/DisallowXDebugSniff.php
@@ -1,15 +1,12 @@
 <?php
 /**
- * This sniff prohibits the use of xdebug functions in production code
+ * Prohibit the use of xdebug functions in production code
  *
  * @author     Platform Team <developer@helpscout.net>
  * @copyright  2015 Help Scout
  */
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
 
-/**
- * This sniff prohibits the use of xdebug functions
- */
 class HelpScout_Sniffs_Functions_DisallowXDebugSniff extends ForbiddenFunctionsSniff
 {
     public $forbiddenFunctions = [
@@ -31,5 +28,3 @@ class HelpScout_Sniffs_Functions_DisallowXDebugSniff extends ForbiddenFunctionsS
         'xdebug_time_index'             => null
     ];
 }
-
-/* End of file DisallowXDebugSniff.php */

--- a/HelpScout/ruleset.xml
+++ b/HelpScout/ruleset.xml
@@ -1,117 +1,172 @@
 <?xml version="1.0"?>
 <ruleset name="HelpScout">
- <description>The Help Scout Coding Standard.</description>
+    <description>The Help Scout Coding Standard.</description>
 
- <!-- Include PSR standards -->
- <rule ref="PSR1"/>
- <rule ref="PSR2"/>
+    <!-- Include PSR standards -->
+    <rule ref="PSR1"/>
+    <rule ref="PSR2"/>
 
- <!-- Include some specific sniffs -->
- <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
- <rule ref="Generic.ControlStructures.InlineControlStructure"/>
- <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
- <rule ref="Generic.Formatting.SpaceAfterCast"/>
- <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
- <rule ref="Generic.NamingConventions.ConstructorName"/>
- <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
- <rule ref="Generic.PHP.DeprecatedFunctions"/>
- <rule ref="Generic.PHP.DisallowShortOpenTag"/>
- <rule ref="Generic.PHP.LowerCaseConstant"/>
- <rule ref="Generic.PHP.LowerCaseKeyword"/>
- <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
- <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
- <rule ref="Generic.WhiteSpace.ScopeIndent"/>
- <rule ref="PEAR.ControlStructures.MultiLineCondition"/>
- <rule ref="PEAR.Formatting.MultiLineAssignment"/>
- <rule ref="PEAR.Functions.ValidDefaultValue"/>
- <rule ref="PSR2.Files.EndFileNewline"/>
- <rule ref="Squiz.Commenting.VariableComment"/>
- <rule ref="Squiz.PHP.CommentedOutCode"/>
- <rule ref="Zend.Debug.CodeAnalyzer"/>
- <rule ref="Zend.Files.ClosingTag"/>
+    <!-- Include some specific sniffs -->
+    <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
 
- <!-- We prefer not to use underscores on private properties -->
- <rule ref="Squiz.NamingConventions.ValidVariableName">
-  <exclude name="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore"/>
- </rule>
+    <!-- Verifies that inline control statements are not present. -->
+    <rule ref="Generic.ControlStructures.InlineControlStructure"/>
 
- <!-- PHPStorm prefers throws annotations from deeper code as well, this causes
-      the number in the method and the number in the phpdoc to mismatch -->
- <rule ref="Squiz.Commenting.FunctionCommentThrowTag">
-  <exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>
- </rule>
+    <!-- Ensures each statement is on a line by itself. -->
+    <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
 
- <!-- Add additional Help Scout sniffs -->
- <rule ref="HelpScout.Functions.DisallowXDebug"/>
+    <!-- Ensures there is a single space after cast tokens. -->
+    <rule ref="Generic.Formatting.SpaceAfterCast"/>
 
- <!-- Allow an exception to concat rules for long line lengths -->
- <rule ref="Generic.Strings.UnnecessaryStringConcat">
-  <properties>
-   <property name="allowMultiline" value="true"/>
-  </properties>
- </rule>
+    <!-- Checks that calls to methods and functions are spaced correctly. -->
+    <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
 
- <!-- Controllers Violate PSR0 -->
- <rule ref="PSR1.Classes.ClassDeclaration">
-  <exclude-pattern>*/controllers/*</exclude-pattern>
- </rule>
- <rule ref="PSR1.Files.SideEffects">
-  <exclude-pattern>*/controllers/*</exclude-pattern>
- </rule>
+    <!-- Makes sure that shorthand PHP open tags are not used. -->
+    <rule ref="Generic.NamingConventions.ConstructorName"/>
 
- <!-- Tests Violate PSR0 -->
- <rule ref="PSR1.Classes.ClassDeclaration">
-  <exclude-pattern>test/*</exclude-pattern>
- </rule>
+    <!-- Ensures that constant names are all uppercase. -->
+    <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
 
- <!-- Lines can be 120 chars long, but never show errors -->
- <rule ref="Generic.Files.LineLength">
-  <properties>
-   <property name="lineLimit" value="80"/>
-   <property name="absoluteLineLimit" value="120"/>
-  </properties>
- </rule>
+    <!-- Discourages the use of deprecated PHP functions. -->
+    <rule ref="Generic.PHP.DeprecatedFunctions"/>
 
- <!-- Use Unix newlines -->
- <rule ref="Generic.Files.LineEndings">
-  <properties>
-   <property name="eolChar" value="\n"/>
-  </properties>
- </rule>
+    <!-- Makes sure that shorthand PHP open tags are not used. -->
+    <rule ref="Generic.PHP.DisallowShortOpenTag"/>
 
- <!-- Have 20 chars padding maximum and always show as errors -->
- <rule ref="Generic.Formatting.MultipleStatementAlignment">
-  <properties>
-   <property name="maxPadding" value="20"/>
-   <property name="error" value="true"/>
-  </properties>
- </rule>
+    <!-- Checks that all uses of true, false and null are lowercase. -->
+    <rule ref="Generic.PHP.LowerCaseConstant"/>
 
- <!-- We allow empty catch statements -->
- <rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedCATCH">
-  <severity>0</severity>
- </rule>
+    <!-- Checks that all PHP keywords are lowercase. -->
+    <rule ref="Generic.PHP.LowerCaseKeyword"/>
 
- <!-- Only one argument per line in multi-line function calls -->
- <rule ref="PEAR.Functions.FunctionCallSignature">
-  <properties>
-   <property name="allowMultipleArguments" value="false"/>
-  </properties>
-  <exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
-  <exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
- </rule>
+    <!-- Checks that two strings are not concatenated together; suggests using one string instead. -->
+    <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
 
- <!-- Relaxing several commenting sniffs from Squiz -->
- <rule ref="Squiz.Commenting.FunctionComment">
-  <exclude name="Squiz.Commenting.FunctionComment.EmptyThrows"/>
-  <exclude name="Squiz.Commenting.FunctionComment.Missing"/>
-  <exclude name="Squiz.Commenting.FunctionComment.MissingReturn"/>
-  <exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
-  <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
-  <exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
-  <exclude name="Squiz.Commenting.FunctionComment.ParamCommentNotCapital"/>
-  <exclude name="Squiz.Commenting.FunctionComment.InvalidReturn"/>
-  <exclude name="Squiz.Commenting.FunctionComment.IncorrectParamVarName"/>
-  <exclude name="Squiz.Commenting.FunctionComment.InvalidTypeHint"/>
- </rule>
+    <!-- Throws errors if tabs are used for indentation. -->
+    <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
+
+    <!-- Checks that control structures are defined and indented correctly. -->
+    <rule ref="Generic.WhiteSpace.ScopeIndent"/>
+
+    <!-- Ensure multi-line IF conditions are defined correctly. -->
+    <rule ref="PEAR.ControlStructures.MultiLineCondition"/>
+
+    <!-- If an assignment goes over two lines, ensure the equal sign is indented. -->
+    <rule ref="PEAR.Formatting.MultiLineAssignment"/>
+
+    <!-- Ensures function params with default values are at the end of the declaration. -->
+    <rule ref="PEAR.Functions.ValidDefaultValue"/>
+
+    <!-- Ensures the file ends with a newline character. Git prefers this. -->
+    <rule ref="PSR2.Files.EndFileNewline"/>
+
+    <!-- Parses and verifies the variable doc comment. -->
+    <rule ref="Squiz.Commenting.VariableComment"/>
+
+    <!-- Warn about commented out code. -->
+    <rule ref="Squiz.PHP.CommentedOutCode"/>
+
+    <!-- Runs the Zend Code Analyzer (from Zend Studio) on the file. -->
+    <rule ref="Zend.Debug.CodeAnalyzer"/>
+
+    <!-- Checks that the file does not end with a closing tag. -->
+    <rule ref="Zend.Files.ClosingTag"/>
+
+    <!-- We prefer not to use underscores on private properties -->
+    <rule ref="Squiz.NamingConventions.ValidVariableName">
+        <exclude name="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore"/>
+    </rule>
+
+    <!-- PHPStorm prefers throws annotations from deeper code as well, -->
+    <!-- this causes the number in the method and the number in the phpdoc -->
+    <!-- to mismatch -->
+    <rule ref="Squiz.Commenting.FunctionCommentThrowTag">
+        <exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>
+    </rule>
+
+    <!-- Prohibit the use of xdebug functions in production code -->
+    <rule ref="HelpScout.Functions.DisallowXDebug"/>
+
+    <!-- Allow an exception to concat rules for long line lengths -->
+    <rule ref="Generic.Strings.UnnecessaryStringConcat">
+        <properties>
+            <property name="allowMultiline" value="true"/>
+        </properties>
+    </rule>
+
+    <!-- Controllers Violate PSR0 -->
+    <rule ref="PSR1.Classes.ClassDeclaration">
+        <exclude-pattern>*/controllers/*</exclude-pattern>
+    </rule>
+    <rule ref="PSR1.Files.SideEffects">
+        <exclude-pattern>*/controllers/*</exclude-pattern>
+    </rule>
+
+    <!-- Tests Violate PSR0 -->
+    <rule ref="PSR1.Classes.ClassDeclaration">
+        <exclude-pattern>test/*</exclude-pattern>
+    </rule>
+
+    <!-- Lines can be 120 chars long, but never show errors -->
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="80"/>
+            <property name="absoluteLineLimit" value="120"/>
+        </properties>
+    </rule>
+
+    <!-- Use Unix newlines -->
+    <rule ref="Generic.Files.LineEndings">
+        <properties>
+            <property name="eolChar" value="\n"/>
+        </properties>
+    </rule>
+
+    <!-- Have 20 chars padding maximum and always show as errors -->
+    <rule ref="Generic.Formatting.MultipleStatementAlignment">
+        <properties>
+            <property name="maxPadding" value="20"/>
+            <property name="error" value="true"/>
+        </properties>
+    </rule>
+
+    <!-- We allow empty catch statements -->
+    <rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedCATCH">
+        <severity>0</severity>
+    </rule>
+
+    <!-- Only one argument per line in multi-line function calls -->
+    <rule ref="PEAR.Functions.FunctionCallSignature">
+        <properties>
+            <property name="allowMultipleArguments" value="false"/>
+        </properties>
+        <!-- Allow content after a open parenthesis. smarty($template, [\n -->
+        <exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
+        <!-- And the same for closing ]); -->
+        <exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
+    </rule>
+
+    <!-- Relaxing several commenting sniffs from Squiz -->
+    <rule ref="Squiz.Commenting.FunctionComment">
+        <!-- Comment missing for @throws tag in function comment -->
+        <exclude name="Squiz.Commenting.FunctionComment.EmptyThrows"/>
+        <!-- Allow no comment at all -->
+        <exclude name="Squiz.Commenting.FunctionComment.Missing"/>
+        <!-- Methods with type definitions don't need an @return -->
+        <exclude name="Squiz.Commenting.FunctionComment.MissingReturn"/>
+        <!-- Type hinted parameters don't need an @param -->
+        <exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
+        <!-- We don't mind a parameter without a comment. Well named is good enough -->
+        <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
+        <!-- No need for periods on the end of comments -->
+        <exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
+        <!-- No need for Capitalization rules, we're not publishing docs -->
+        <exclude name="Squiz.Commenting.FunctionComment.ParamCommentNotCapital"/>
+        <!-- We occasionally need to lie about Doctrine returns types -->
+        <exclude name="Squiz.Commenting.FunctionComment.InvalidReturn"/>
+        <!-- We occasionally need to lie about Doctrine parameter types in the phpdocs -->
+        <exclude name="Squiz.Commenting.FunctionComment.IncorrectParamVarName"/>
+        <!-- We occasionally need to lie about Doctrine returns types -->
+        <exclude name="Squiz.Commenting.FunctionComment.InvalidTypeHint"/>
+    </rule>
 </ruleset>


### PR DESCRIPTION
# Problem 
In some upcoming changes, it'll be useful to have a well commented ruleset file. This adds comments, and should have no other side effects.

# Solution
Add comments, mostly pulled from the headers of the various sniffs that this config references. In addition, this updated the indenting in the XML file.